### PR TITLE
Change cursor for title in topbar

### DIFF
--- a/lib/app/lib/topbar/index.css
+++ b/lib/app/lib/topbar/index.css
@@ -9,7 +9,7 @@
   margin-left: var(--space-large-px);
   color: var(--color-silver);
   font-size: 18px;
-  /*font-weight: bold;*/
+  cursor: default;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
Title is drag-able element so it's unable to select text in topbar therefore no reason to show text selection cursor for title
