### PR TITLE
Add/exit

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
 </head>
 <body>
   <div id="main"></div>
+  <script>
+  var electronRequire
+  if (window.require) electronRequire = require
+  </script>
   <script src="build/index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 const app = require('app')
 const BrowserWindow = require('browser-window')
+const ipc = require('ipc')
 const Menu = require('menu')
 const menuTemplate = require('./menu-template.js')
 
@@ -25,6 +26,10 @@ function createMainWindow () {
   win.on('closed', onClosed)
   return win
 }
+
+ipc.on('quit', function () {
+  app.quit()
+})
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()

--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -8,6 +8,7 @@ const name = 'App'
 
 let propTypes = {
   err: {source: 'err'},
+  electron: {source: 'electron'},
   settings: {source: 'settings'},
   connected: {source: 'connected'},
   client: {source: 'client'},

--- a/lib/app/lib/topbar/index.css
+++ b/lib/app/lib/topbar/index.css
@@ -21,6 +21,10 @@
   border-radius: 0px;
   background: var(--color-dark-blue);
   padding: 3px 10px 3px 10px;
+  margin: 0px 5px 0px 0px;
+}
+
+.Topbar-button:last-of-type {
   margin: 0;
 }
 

--- a/lib/app/lib/topbar/index.js
+++ b/lib/app/lib/topbar/index.js
@@ -7,12 +7,17 @@ function logOut () {
   bus.emit('network:disconnect')
 }
 
+function quit () {
+  bus.emit('ipc:quit')
+}
+
 /**
  * Topbar Component
  */
 function render (component) {
   let props = component.props
   let logOutButton = null
+  let quitButton = null
 
   if (props.connected) {
     logOutButton = dom('button', {
@@ -21,10 +26,18 @@ function render (component) {
     }, 'Log Out')
   }
 
+  if (props.electron) {
+    quitButton = dom('button', {
+      class: 'Button Topbar-button',
+      onClick: quit
+    }, 'Quit')
+  }
+
   return dom('div', {class: 'Topbar'}, [
     dom('span', {class: 'Topbar-title'}, 'Blox Party'),
     dom('div', {class: 'Topbar-buttons'}, [
-      logOutButton
+      logOutButton,
+      quitButton
     ])
   ])
 }

--- a/lib/index.css
+++ b/lib/index.css
@@ -29,14 +29,14 @@
 
 @font-face {
   font-family: 'PT Sans';
-  src: url('/lib/fonts/PT_Sans/PT_Sans-Web-Regular.ttf') format('truetype');
+  src: url('fonts/PT_Sans/PT_Sans-Web-Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'PT Sans';
-  src: url('/lib/fonts/PT_Sans/PT_Sans-Web-Bold.ttf') format('truetype');
+  src: url('fonts/PT_Sans/PT_Sans-Web-Bold.ttf') format('truetype');
   font-weight: bold;
   font-style: normal;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,12 @@ import socket from './socket'
 import routes from './routes'
 import actions from './actions'
 import board from './board'
+import ipc from './ipc'
 import App from './app'
 
 let app = tree(dom(App))
 
+app.set('electron', false)
 app.set('connected', false)
 app.set('client', {})
 app.set('stats', {
@@ -16,10 +18,15 @@ app.set('stats', {
   players: []
 })
 
+if (window && window.process && window.process.versions['electron']) {
+  app.set('electron', true)
+}
+
 app.use(settings)
 app.use(board)
 app.use(socket)
 app.use(routes)
 app.use(actions)
+app.use(ipc)
 
 render(app, document.querySelector('#main'))

--- a/lib/ipc/index.js
+++ b/lib/ipc/index.js
@@ -1,0 +1,13 @@
+/*global electronRequire*/
+import bus from 'bus'
+
+export default function IPC (app) {
+  if (!window || !window.process || !window.process.versions['electron']) return
+  app.set('electron', true)
+  let ipc = electronRequire('ipc')
+
+  bus.on('ipc:quit', function () {
+    console.log('sending')
+    ipc.send('quit')
+  })
+}


### PR DESCRIPTION
This adds a 'Quit' button into the toolbar, as well as adding an interface to Electron's ipc module.  The app will detect if it's being run in a browser or Electron context and will not load the ipc module if the app is not running within Electron.
